### PR TITLE
Wrapper commands for list and forge tps

### DIFF
--- a/modules/mineapi/src/commands/index.ts
+++ b/modules/mineapi/src/commands/index.ts
@@ -6,6 +6,7 @@ export * from "./properties";
 export * from "./property";
 export * from "./status";
 export * from "./tpo";
+export * from "./tps";
 export * from "./username";
 export * from "./uuid";
 export * from "./whereis";

--- a/modules/mineapi/src/commands/index.ts
+++ b/modules/mineapi/src/commands/index.ts
@@ -7,6 +7,7 @@ export * from "./property";
 export * from "./status";
 export * from "./tpo";
 export * from "./tps";
+export * from "./tpss";
 export * from "./username";
 export * from "./uuid";
 export * from "./whereis";

--- a/modules/mineapi/src/commands/index.ts
+++ b/modules/mineapi/src/commands/index.ts
@@ -1,5 +1,6 @@
 export * from "./getSpawn";
 export * from "./leveldat";
+export * from "./list";
 export * from "./playerdata";
 export * from "./properties";
 export * from "./property";

--- a/modules/mineapi/src/commands/list.ts
+++ b/modules/mineapi/src/commands/list.ts
@@ -1,46 +1,39 @@
 // Import Types
 import { Command } from "@spookelton/wrapperHelpers/types";
 
-import { getCore, thread } from ".."
+import { getStatus } from ".."
 import { helpHelper, strOut } from "@spookelton/wrapperHelpers/modul";
 
 export const list: Command = async (message) => {
-	// Execute the list command
-	const wrapperThread = await getCore();
-	await wrapperThread.serverStdin("list\n");
+	const serverStatus = await getStatus();
 
-	// Get the server's response to the command
-	// TODO: Set a timeout for this.
-	const result = await new Promise<RegExpMatchArray>((resolve, reject) => {
-		// TODO: Make sure this format works for relevant minecraft versions.
-		const regex = new RegExp(String.raw
-			`\[\d+:\d+:\d+\] \[Server thread\/INFO\]: There are (\d+) of a max of (\d+) players online: (.+( ,)?)*`
-		);
+	const { maxPlayers, onlinePlayers, samplePlayers } = serverStatus;
+	const onlineMessage = samplePlayers?.length
+						  ? `:\n${samplePlayers.map(x => x.name).join(", ")}`
+						  : ".\nIt is quite lonely.";
 
-		const getMatch = (line: string) => {
-			const maybeMatch = line.match(regex);
-
-			if (maybeMatch === null) return;
-
-			thread.removeListener("serverStdout", getMatch);
-			resolve(maybeMatch);
-		}
-
-		thread.on("serverStdout", getMatch);
-	});
-
-	// Construct a custom message with info extracted from server output
-	const numOnline = result[1];
-	const numMax = result[2];
-	const onlinePlayers: string | undefined = result[3];
-	const onlinePlayersMessage = onlinePlayers ? `:\n${onlinePlayers}` : ".\nIt is quite lonely.";
-
-	const outputMessage = `There are ${numOnline}/${numMax} players online${onlinePlayersMessage}`;
+	const outputMessage = `There are ${onlinePlayers}/${maxPlayers} players online` + onlineMessage;
 
 	// TODO: Make better formatting.
+	// Includes perhaps showing more detailed userinfo, icon, etc.
 	// TODO: Do I have to do something to handle console/ingame output? Ideally there should be no output there, or
 	// just the raw command output? Or maybe we can use the formatted output as well.
-	return strOut(outputMessage);
+	return {
+		console: outputMessage,
+		minecraft: outputMessage,
+		discord: {
+			embeds: [
+				{
+					title: outputMessage,
+					timestamp: Date.now(),
+					author: {
+						name: "",
+						icon_url: "https://cdn.discordapp.com/avatars/300050030923087872/b85c91512bf80b884a75548e71b9a817.webp"
+					},
+				},
+			],
+		}
+	};
 };
 list.help = helpHelper({
 	commandString: "~list",

--- a/modules/mineapi/src/commands/list.ts
+++ b/modules/mineapi/src/commands/list.ts
@@ -1,15 +1,16 @@
 // Import Types
 import { Command } from "@spookelton/wrapperHelpers/types";
 
-
 import { getCore, getStatus } from ".."
 import { helpHelper, strOut } from "@spookelton/wrapperHelpers/modul";
 import { hex } from "@spookelton/wrapperHelpers/colors";
+
 
 export const list: Command = async (message) => {
 	const core = await getCore();
 	if (!await core.serverStarted()) return strOut("Server is still starting! Please wait...", "red");
 
+	// TODO: Make sure samplePlayers includes ALL players
 	const serverStatus = await getStatus();
 	const { maxPlayers, onlinePlayers, samplePlayers } = serverStatus;
 

--- a/modules/mineapi/src/commands/list.ts
+++ b/modules/mineapi/src/commands/list.ts
@@ -18,22 +18,7 @@ export const list: Command = async (message) => {
 	// Includes perhaps showing more detailed userinfo, icon, etc.
 	// TODO: Do I have to do something to handle console/ingame output? Ideally there should be no output there, or
 	// just the raw command output? Or maybe we can use the formatted output as well.
-	return {
-		console: outputMessage,
-		minecraft: outputMessage,
-		discord: {
-			embeds: [
-				{
-					title: outputMessage,
-					timestamp: Date.now(),
-					author: {
-						name: "",
-						icon_url: "https://cdn.discordapp.com/avatars/300050030923087872/b85c91512bf80b884a75548e71b9a817.webp"
-					},
-				},
-			],
-		}
-	};
+	return strOut(outputMessage)
 };
 list.help = helpHelper({
 	commandString: "~list",

--- a/modules/mineapi/src/commands/list.ts
+++ b/modules/mineapi/src/commands/list.ts
@@ -1,0 +1,49 @@
+// Import Types
+import { Command, CoreExports } from "@spookelton/wrapperHelpers/types";
+import type { ThreadModule } from "@inrixia/threads";
+
+import { helpHelper, strOut } from "@spookelton/wrapperHelpers/modul";
+
+export const list: Command = async (message) => {
+	const thread = (module.parent!.parent!.parent as ThreadModule).thread;
+	const wrapperThread = await thread.require<CoreExports>("@spookelton/serverWrapper");
+
+	// Execute the list command
+	await wrapperThread.serverStdin("list\n");
+
+	// Get the server's response to the command
+	const result = await new Promise<RegExpMatchArray>((resolve, reject) => {
+		// TODO: Make sure this format works for relevant minecraft versions.
+		const regex = new RegExp(String.raw
+			`\[\d+:\d+:\d+\] \[Server thread\/INFO\]: There are (\d+) of a max of (\d+) players online: (.+( ,)?)*`
+		);
+
+		const getMatch = (line: string) => {
+			const maybeMatch = line.match(regex);
+
+			if (maybeMatch === null) return;
+
+			thread.removeListener("serverStdout", getMatch);
+			resolve(maybeMatch);
+		}
+
+		thread.on("serverStdout", getMatch);
+	});
+
+	// Construct a custom message with info extracted from server output
+	const numOnline = result[1];
+	const numMax = result[2];
+	const onlinePlayers: string | undefined = result[3];
+	const onlinePlayersMessage = onlinePlayers ? `:\n${onlinePlayers}` : ".\nIt is quite lonely.";
+
+	const outputMessage = `There are ${numOnline}/${numMax} players online${onlinePlayersMessage}`;
+
+	// TODO: Make better formatting.
+	// TODO: Do I have to do something to handle console/ingame output? Ideally there should be no output there, or
+	// just the raw command output? Or maybe we can use the formatted output as well.
+	return strOut(outputMessage);
+};
+list.help = helpHelper({
+	commandString: "~list",
+	summary: "Lists the current users on the server.",
+});

--- a/modules/mineapi/src/commands/list.ts
+++ b/modules/mineapi/src/commands/list.ts
@@ -9,15 +9,13 @@ export const list: Command = async (message) => {
 
 	const { maxPlayers, onlinePlayers, samplePlayers } = serverStatus;
 	const onlineMessage = samplePlayers?.length
-						  ? `:\n${samplePlayers.map(x => x.name).join(", ")}`
+						  ? `:\n${samplePlayers.map(player => player.name).join(", ")}`
 						  : ".\nIt is quite lonely.";
 
 	const outputMessage = `There are ${onlinePlayers}/${maxPlayers} players online` + onlineMessage;
 
 	// TODO: Make better formatting.
-	// Includes perhaps showing more detailed userinfo, icon, etc.
-	// TODO: Do I have to do something to handle console/ingame output? Ideally there should be no output there, or
-	// just the raw command output? Or maybe we can use the formatted output as well.
+	// Show more detailed userinfo (e.g. user head, icon).
 	return strOut(outputMessage)
 };
 list.help = helpHelper({

--- a/modules/mineapi/src/commands/list.ts
+++ b/modules/mineapi/src/commands/list.ts
@@ -1,22 +1,34 @@
 // Import Types
 import { Command } from "@spookelton/wrapperHelpers/types";
 
-import { getStatus } from ".."
+
+import { getCore, getStatus } from ".."
 import { helpHelper, strOut } from "@spookelton/wrapperHelpers/modul";
+import { hex } from "@spookelton/wrapperHelpers/colors";
 
 export const list: Command = async (message) => {
+	const core = await getCore();
+	if (!await core.serverStarted()) return strOut("Server is still starting! Please wait...", "red");
+
 	const serverStatus = await getStatus();
-
 	const { maxPlayers, onlinePlayers, samplePlayers } = serverStatus;
+
+	const titleMessage = `There are ${onlinePlayers}/${maxPlayers} players online:`;
 	const onlineMessage = samplePlayers?.length
-						  ? `:\n${samplePlayers.map(player => player.name).join(", ")}`
-						  : ".\nIt is quite lonely.";
+						  ? samplePlayers.map(player => player.name).join(", ")
+						  : "It is quite lonely.";
 
-	const outputMessage = `There are ${onlinePlayers}/${maxPlayers} players online` + onlineMessage;
-
-	// TODO: Make better formatting.
-	// Show more detailed userinfo (e.g. user head, icon).
-	return strOut(outputMessage)
+	// TODO: Make better formatting. Show more detailed userinfo (e.g. user head, icon).
+	return {
+		minecraft: `${titleMessage} ${onlineMessage}`,
+		console: `${titleMessage} ${onlineMessage}`,
+		discord: {embeds: [{
+			title: titleMessage,
+			description: onlineMessage,
+			timestamp: Date.now(),
+			color: parseInt(hex.green, 16),
+		}]}
+	};
 };
 list.help = helpHelper({
 	commandString: "~list",

--- a/modules/mineapi/src/commands/list.ts
+++ b/modules/mineapi/src/commands/list.ts
@@ -1,17 +1,16 @@
 // Import Types
-import { Command, CoreExports } from "@spookelton/wrapperHelpers/types";
-import type { ThreadModule } from "@inrixia/threads";
+import { Command } from "@spookelton/wrapperHelpers/types";
 
+import { getCore, thread } from ".."
 import { helpHelper, strOut } from "@spookelton/wrapperHelpers/modul";
 
 export const list: Command = async (message) => {
-	const thread = (module.parent!.parent!.parent as ThreadModule).thread;
-	const wrapperThread = await thread.require<CoreExports>("@spookelton/serverWrapper");
-
 	// Execute the list command
+	const wrapperThread = await getCore();
 	await wrapperThread.serverStdin("list\n");
 
 	// Get the server's response to the command
+	// TODO: Set a timeout for this.
 	const result = await new Promise<RegExpMatchArray>((resolve, reject) => {
 		// TODO: Make sure this format works for relevant minecraft versions.
 		const regex = new RegExp(String.raw

--- a/modules/mineapi/src/commands/tps.ts
+++ b/modules/mineapi/src/commands/tps.ts
@@ -1,110 +1,29 @@
 // Import Types
 import { Command } from "@spookelton/wrapperHelpers/types";
-import type { MessageEmbedOptions } from "discord.js";
 
-import { thread, getCore } from "..";
 import { helpHelper } from "@spookelton/wrapperHelpers/modul";
-import { hex } from "@spookelton/wrapperHelpers/colors"
-import { ColorKey } from "@spookelton/wrapperHelpers/types"
 
-type TpsResponse = {
-	dimensions: {
-		dimId: string,
-		dimName: string | null,
-		tickTime: number,
-		tps: number,
-	}[],
-	overall: {
-		tickTime: number,
-		tps: number,
-	},
-}
+// Import helper functions for tps handling.
+import { runTpsCommand, tpsToColor } from "../lib/tps"
 
-function parseOutput(input: RegExpMatchArray[]): TpsResponse {
-	// We don't want the Overall tps to be parsed as a dimension, so remove it and store it for later
-	const inputOverall = input.pop();
-	if (!inputOverall) throw new Error("It seems like something bad happened I'll change this error later");
-
-	const output = {
-		dimensions: input.map(x => ({
-			dimId: x[1].replace(/Dim  ?/, ""),  // Remove extra "Dim" at the start
-			dimName: x[2] === "null" ? null : x[2],
-			tickTime: parseFloat(x[3]),
-			tps: parseFloat(x[4]),
-		})),
-		overall: {
-			tickTime: parseFloat(inputOverall[3]),
-			tps: parseFloat(inputOverall[4]),
-		}
-	};
-
-	return output;
-}
-
-function tpsToColor(tps: number): number {
-	let colorName: ColorKey;
-	if (tps < 10) {
-		colorName = "red";
-	} else if (tps < 15) {
-		colorName = "yellow";
-	} else {
-		colorName = "green"
-	}
-
-	return parseInt(hex[colorName], 16)
-}
 
 export const tps: Command = async (message) => {
-	const wrapperThread = await getCore();
+	// Run the tps command, and wait for a response from server console.
+	const result = await runTpsCommand();
 
-	// Execute the "/forge tps" command
-	await wrapperThread.serverStdin("forge tps\n");
-
-	// Get the server's response to the command
-	const result = await new Promise<TpsResponse>((resolve, reject) => {
-		const results: RegExpMatchArray[] = [];
-
-		// TODO: Make sure this format works for relevant minecraft versions.
-		const regex = /\[\d{2}:\d{2}:\d{2}\] \[Server thread\/INFO\](?: \[minecraft\/DedicatedServer\])?: (Dim .+?:.+?|Dim [ -]?\d+?|Overall)(?: \((.+?)\))? ?: Mean tick time: ([-+]?[0-9]*\.?[0-9]+) ms. Mean TPS: ([-+]?[0-9]*\.?[0-9]+)/g
-
-		const getMatchs = (lines: string) => {
-			const matches = lines.matchAll(regex);
-			for (let match of matches) {
-				results.push(match)
-
-				// The last line of the command output will have a dimension of Overall
-				if (match[1] === "Overall") {
-					thread.removeListener("serverStdout", getMatchs);
-					resolve(parseOutput(results));
-				}
-			}
+	// Construct the message containing overall tps
+	return {
+		discord: {
+			embeds: [{
+				title: "Overall Server TPS:",
+				description: `**TPS**: \`${result.overall.tps}\`\n**Tick Time**: \`${result.overall.tickTime}\` ms`,
+				color: tpsToColor(result.overall.tps),
+				timestamp: Date.now(),
+			}]
 		}
-
-		thread.on("serverStdout", getMatchs);
-	});
-
-	console.log(result)
-
-	// Construct a custom message with info extracted from server output
-	const embed: MessageEmbedOptions = {
-		title: "Server TPS:",
-		fields: [
-			...result.dimensions.map(x => ({
-				name: `${x.dimId} (${x.dimName})`,
-				value: `**Mean tick time**: ${x.tickTime} ms\n**Mean TPS**: ${x.tps}`
-			})),
-			{
-				name: "Overall",
-				value: `**Mean tick time**: ${result.overall.tickTime} ms\n**Mean TPS**: ${result.overall.tps}`
-			}
-		],
-		color: tpsToColor(result.overall.tps),
-		timestamp: Date.now(),
-	}
-
-	return { discord: { embeds: [embed] } };
+	};
 };
 tps.help = helpHelper({
 	commandString: "~tps",
-	summary: "Returns the TPS of the server.",
+	summary: "Returns the overall TPS of the server.",
 });

--- a/modules/mineapi/src/commands/tps.ts
+++ b/modules/mineapi/src/commands/tps.ts
@@ -27,7 +27,7 @@ function parseOutput(input: RegExpMatchArray[]): TpsResponse {
 
 	const output = {
 		dimensions: input.map(x => ({
-			dimId: x[1].replace(/Dim  ?/, ""),
+			dimId: x[1].replace(/Dim  ?/, ""),  // Remove extra "Dim" at the start
 			dimName: x[2] === "null" ? null : x[2],
 			tickTime: parseFloat(x[3]),
 			tps: parseFloat(x[4]),

--- a/modules/mineapi/src/commands/tps.ts
+++ b/modules/mineapi/src/commands/tps.ts
@@ -1,0 +1,110 @@
+// Import Types
+import { Command } from "@spookelton/wrapperHelpers/types";
+import type { MessageEmbedOptions } from "discord.js";
+
+import { thread, getCore } from "..";
+import { helpHelper } from "@spookelton/wrapperHelpers/modul";
+import { hex } from "@spookelton/wrapperHelpers/colors"
+import { ColorKey } from "@spookelton/wrapperHelpers/types"
+
+type TpsResponse = {
+	dimensions: {
+		dimId: string,
+		dimName: string | null,
+		tickTime: number,
+		tps: number,
+	}[],
+	overall: {
+		tickTime: number,
+		tps: number,
+	},
+}
+
+function parseOutput(input: RegExpMatchArray[]): TpsResponse {
+	// We don't want the Overall tps to be parsed as a dimension, so remove it and store it for later
+	const inputOverall = input.pop();
+	if (!inputOverall) throw new Error("It seems like something bad happened I'll change this error later");
+
+	const output = {
+		dimensions: input.map(x => ({
+			dimId: x[1].replace(/Dim  ?/, ""),
+			dimName: x[2] === "null" ? null : x[2],
+			tickTime: parseFloat(x[3]),
+			tps: parseFloat(x[4]),
+		})),
+		overall: {
+			tickTime: parseFloat(inputOverall[3]),
+			tps: parseFloat(inputOverall[4]),
+		}
+	};
+
+	return output;
+}
+
+function tpsToColor(tps: number): number {
+	let colorName: ColorKey;
+	if (tps < 10) {
+		colorName = "red";
+	} else if (tps < 15) {
+		colorName = "yellow";
+	} else {
+		colorName = "green"
+	}
+
+	return parseInt(hex[colorName], 16)
+}
+
+export const tps: Command = async (message) => {
+	const wrapperThread = await getCore();
+
+	// Execute the "/forge tps" command
+	await wrapperThread.serverStdin("forge tps\n");
+
+	// Get the server's response to the command
+	const result = await new Promise<TpsResponse>((resolve, reject) => {
+		const results: RegExpMatchArray[] = [];
+
+		// TODO: Make sure this format works for relevant minecraft versions.
+		const regex = /\[\d{2}:\d{2}:\d{2}\] \[Server thread\/INFO\](?: \[minecraft\/DedicatedServer\])?: (Dim .+?:.+?|Dim [ -]?\d+?|Overall)(?: \((.+?)\))? ?: Mean tick time: ([-+]?[0-9]*\.?[0-9]+) ms. Mean TPS: ([-+]?[0-9]*\.?[0-9]+)/g
+
+		const getMatchs = (lines: string) => {
+			const matches = lines.matchAll(regex);
+			for (let match of matches) {
+				results.push(match)
+
+				// The last line of the command output will have a dimension of Overall
+				if (match[1] === "Overall") {
+					thread.removeListener("serverStdout", getMatchs);
+					resolve(parseOutput(results));
+				}
+			}
+		}
+
+		thread.on("serverStdout", getMatchs);
+	});
+
+	console.log(result)
+
+	// Construct a custom message with info extracted from server output
+	const embed: MessageEmbedOptions = {
+		title: "Server TPS:",
+		fields: [
+			...result.dimensions.map(x => ({
+				name: `${x.dimId} (${x.dimName})`,
+				value: `**Mean tick time**: ${x.tickTime} ms\n**Mean TPS**: ${x.tps}`
+			})),
+			{
+				name: "Overall",
+				value: `**Mean tick time**: ${result.overall.tickTime} ms\n**Mean TPS**: ${result.overall.tps}`
+			}
+		],
+		color: tpsToColor(result.overall.tps),
+		timestamp: Date.now(),
+	}
+
+	return { discord: { embeds: [embed] } };
+};
+tps.help = helpHelper({
+	commandString: "~tps",
+	summary: "Returns the TPS of the server.",
+});

--- a/modules/mineapi/src/commands/tps.ts
+++ b/modules/mineapi/src/commands/tps.ts
@@ -17,7 +17,7 @@ export const tps: Command = async (message) => {
 			embeds: [{
 				title: "Overall Server TPS:",
 				description: `**TPS**: \`${result.overall.tps}\`\n**Tick Time**: \`${result.overall.tickTime}\` ms`,
-				color: tpsToColor(result.overall.tps),
+				color: parseInt(tpsToColor(result.overall.tps), 16),
 				timestamp: Date.now(),
 			}]
 		}

--- a/modules/mineapi/src/commands/tpss.ts
+++ b/modules/mineapi/src/commands/tpss.ts
@@ -1,0 +1,31 @@
+// Import Types
+import { Command } from "@spookelton/wrapperHelpers/types";
+
+import { helpHelper } from "@spookelton/wrapperHelpers/modul";
+
+// Import helper functions for tps handling.
+import { runTpsCommand, tpsToColor, formatDimension } from "../lib/tps"
+
+
+export const tpss: Command = async (message) => {
+    // Run the tps command, and wait for a response from server console.
+	const result = await runTpsCommand();
+
+	// Construct the message containing tps info
+	return {
+        discord: {
+            embeds: [{
+                title: "Server TPS:",
+                description:
+                    result.dimensions.map(formatDimension).join("\n") +
+                    `\n\n**Overall**:\n TPS: \`${result.overall.tps}\`, Tick Time: \`${result.overall.tickTime}\` ms`,
+                color: tpsToColor(result.overall.tps),
+                timestamp: Date.now(),
+            }]
+        }
+    };
+};
+tpss.help = helpHelper({
+	commandString: "~tpss",
+	summary: "Returns detailed information on the TPS of the server.",
+});

--- a/modules/mineapi/src/commands/tpss.ts
+++ b/modules/mineapi/src/commands/tpss.ts
@@ -18,7 +18,7 @@ export const tpss: Command = async (message) => {
                 title: "Server TPS:",
                 description:
                     result.dimensions.map(formatDimension).join("\n") +
-                    `\n\n**Overall**:\n TPS: \`${result.overall.tps}\`, Tick Time: \`${result.overall.tickTime}\` ms`,
+                    `\n\n**Overall**:\n TPS: \`${result.overall.tps}\` • Tick Time: \`${result.overall.tickTime}\` ms`,
                 color: tpsToColor(result.overall.tps),
                 timestamp: Date.now(),
             }]

--- a/modules/mineapi/src/commands/tpss.ts
+++ b/modules/mineapi/src/commands/tpss.ts
@@ -19,7 +19,7 @@ export const tpss: Command = async (message) => {
                 description:
                     result.dimensions.map(formatDimension).join("\n") +
                     `\n\n**Overall**:\n TPS: \`${result.overall.tps}\` • Tick Time: \`${result.overall.tickTime}\` ms`,
-                color: tpsToColor(result.overall.tps),
+                color: parseInt(tpsToColor(result.overall.tps), 16),
                 timestamp: Date.now(),
             }]
         }

--- a/modules/mineapi/src/lib/tps.ts
+++ b/modules/mineapi/src/lib/tps.ts
@@ -1,0 +1,99 @@
+import { thread, getCore } from "..";
+
+import { hex } from "@spookelton/wrapperHelpers/colors"
+import { ColorKey } from "@spookelton/wrapperHelpers/types"
+
+
+type dimInfo = {
+	dimId: string,
+	dimName: string | null,
+	tickTime: number,
+	tps: number,
+};
+
+type TpsResponse = {
+	dimensions: dimInfo[],
+	overall: {
+		tickTime: number,
+		tps: number,
+	},
+};
+
+
+// TODO: Check for a "command not found error", if found reject
+// TODO: Make sure this format works for relevant minecraft versions.
+const tpsRegExp = /\[\d{2}:\d{2}:\d{2}\] \[Server thread\/INFO\](?: \[minecraft\/DedicatedServer\])?: (Dim .+?:.+?|Dim [ -]?\d+?|Overall)(?: \((.+?)\))? ?: Mean tick time: ([-+]?[0-9]*\.?[0-9]+) ms. Mean TPS: ([-+]?[0-9]*\.?[0-9]+)/g;
+
+export function runTpsCommand(): Promise<TpsResponse> {
+    return new Promise<TpsResponse>((resolve, reject) => {
+		const results: RegExpMatchArray[] = [];
+
+		const getMatches = (lines: string) => {
+			const matches = lines.matchAll(tpsRegExp);
+
+			for (let match of matches) {
+				results.push(match);
+
+				// The last line of the command output will have a dimension of Overall
+				if (match[1] === "Overall") {
+					thread.removeListener("serverStdout", getMatches);
+					resolve(parseOutput(results));
+				}
+			}
+		}
+
+		thread.on("serverStdout", getMatches);
+
+        // Double check if this fixes the problem where the response could come before I started listening
+        getCore().then(wrapperThread => wrapperThread.serverStdin("forge tps\n"));
+	});
+}
+
+function parseOutput(input: RegExpMatchArray[]): TpsResponse {
+	// We don't want the Overall tps to be parsed as a dimension, so remove it and store it for later
+	const overall = input.pop();
+	if (!overall) throw new Error("Input match array is empty, possibly due to failure to parse server output.");
+
+	return {
+		dimensions: input.map(dimMatch => ({
+			dimId: dimMatch[1].replace(/Dim  ?/, ""),  // Remove extra "Dim" text at start
+			dimName: dimMatch[2] === "null" ? null : dimMatch[2],
+			tickTime: +dimMatch[3],
+			tps: +dimMatch[4],
+		})),
+		overall: {
+			tickTime: +overall[3],
+			tps: +overall[4],
+		}
+	};
+}
+
+export function tpsToColor(tps: number): number {
+	let colorName: ColorKey;
+	if (tps < 10) colorName = "red";
+	else if (tps < 18) colorName = "yellow";
+	else colorName = "green";
+
+	return parseInt(hex[colorName], 16);
+}
+
+function capitalize(input: string): string {
+	return input.charAt(0).toUpperCase() + input.slice(1);
+}
+
+export function formatDimension(dim: dimInfo): string {
+    // TODO: I really need to look at this more so it's less bad
+	let [modName, dimensionName] = dim.dimId.split(':', 2);
+	let name;
+
+	// If the main name isn't a dimension id, use it for dimension and mod names.
+	if (isNaN(+modName)) {
+		// Don't show "minecraft:" on vanilla dimensions
+		name = modName === "minecraft" ? dimensionName : `${capitalize(modName)}: ${dimensionName}`;
+	} else {
+		// If it is an id, use the dimension name instead (1.12 compatability)
+		name = dimensionName;
+	}
+
+	return `**${name}**:\n TPS: \`${dim.tps}\`, Tick Time: \`${dim.tickTime}\` ms`;
+}

--- a/modules/mineapi/src/lib/tps.ts
+++ b/modules/mineapi/src/lib/tps.ts
@@ -95,5 +95,5 @@ export function formatDimension(dim: dimInfo): string {
 		name = dimensionName;
 	}
 
-	return `**${name}**:\n TPS: \`${dim.tps}\`, Tick Time: \`${dim.tickTime}\` ms`;
+	return `**${name}**:\n TPS: \`${dim.tps}\` • Tick Time: \`${dim.tickTime}\` ms`;
 }

--- a/modules/mineapi/src/lib/tps.ts
+++ b/modules/mineapi/src/lib/tps.ts
@@ -78,7 +78,7 @@ function capitalize(input: string): string {
 }
 
 export function formatDimension(dim: dimInfo): string {
-    // TODO: I really need to look at this more so it's less bad
+    // TODO: Fix code style, make sure this format works for all versions of minecraft.
 	let [modName, dimensionName] = dim.dimId.split(':', 2);
 	let name;
 

--- a/modules/mineapi/src/lib/tps.ts
+++ b/modules/mineapi/src/lib/tps.ts
@@ -1,7 +1,6 @@
 import { thread, getCore } from "..";
 
 import { hex } from "@spookelton/wrapperHelpers/colors"
-import { ColorKey } from "@spookelton/wrapperHelpers/types"
 
 
 type dimInfo = {
@@ -68,13 +67,10 @@ function parseOutput(input: RegExpMatchArray[]): TpsResponse {
 	};
 }
 
-export function tpsToColor(tps: number): number {
-	let colorName: ColorKey;
-	if (tps < 10) colorName = "red";
-	else if (tps < 18) colorName = "yellow";
-	else colorName = "green";
-
-	return parseInt(hex[colorName], 16);
+export function tpsToColor(tps: number): string {
+	if (tps < 10) return hex.red;
+	if (tps < 18) return hex.yellow;
+	return hex.green;
 }
 
 function capitalize(input: string): string {


### PR DESCRIPTION
This pull request is a WIP, and is not complete.

### Overview
This pull request adds wrapper commands for the in-game commands `/list` and `/forge tps`. 

### Reasoning
`/list` and `/forge tps` are very common commands, often used to check the status of servers. Because of this, it would be nice to have them formatted in a better way, and ensure that no extra console output leaks out when running this command on all servers.

### Implementation
We essentially just run the command in server console, and then wait until we find the output of said command, which we match using regex. After a match, we can extract the relevant data, and format it to our liking.

### TODOs
- [ ] Do the `/forge tps` wrapper, error handling for running on vanilla.
- [ ] Better error handling in general, timeout for waiting for server output.
- [ ] Better formatting/colors.
- [ ] Check how this works in game an in console.